### PR TITLE
Capture limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ sudo dnf install -y SDL2_image-devel
 sudo dnf install -y git gcc g++ libevent libevent-devel openssl openssl-devel \
   gnutls gnutls-devel meson boost boost-devel python3-pip libdrm libdrm-devel \
   systemd-udev doxygen cmake graphviz libatomic texlive-latex cppcheck \
-  libyaml-devel clang zip valgrind libasan findutils
+  libyaml-devel clang zip valgrind libasan findutils systemd-devel
 ```
 
 On Clear Linux:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ericcurtin_twincam&metric=bugs)](https://sonarcloud.io/summary/new_code?id=ericcurtin_twincam)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ericcurtin_twincam&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=ericcurtin_twincam)
 
-A lightweight camera application, designed to start quickly in a bare environment
+A lightweight camera application, designed to start quickly in a bare
+environment. It is named twincam as it is built with automotive in mind
+like a twin-cam engine, it is simply the name of the application.
 
 # To build, install and run twincam
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ On Fedora (steps should be similar on other platforms):
 sudo dnf install -y git gcc g++ libevent libevent-devel openssl openssl-devel \
   gnutls gnutls-devel meson boost boost-devel python3-pip libdrm libdrm-devel \
   systemd-udev doxygen cmake graphviz libatomic texlive-latex cppcheck \
-  libyaml-devel clang zip valgrind libasan findutils SDL2_image-devel
+  libyaml-devel clang zip valgrind libasan findutils SDL2_image-devel \
+  systemd-devel
 ```
 
 On CentOS Stream 9:

--- a/src/camera_session.cpp
+++ b/src/camera_session.cpp
@@ -235,8 +235,8 @@ int CameraSession::startCapture() {
     }
   }
 
-	if (opts.capture_limit)
-		printf("cam: %u: Capture %lu frames\n", cameraIndex_, opts.capture_limit);
+  if (opts.capture_limit)
+    printf("cam: %u: Capture %lu frames\n", cameraIndex_, opts.capture_limit);
   else
     PRINT("cam%u: Capture until user interrupts by SIGINT\n", cameraIndex_);
 
@@ -333,7 +333,6 @@ void CameraSession::processRequest(Request* request) {
     captureDone.emit();
     return;
   }
-
 
   /*
    * If the frame sink holds on the request, we'll requeue it later in the

--- a/src/sdl_sink.cpp
+++ b/src/sdl_sink.cpp
@@ -156,8 +156,7 @@ void SDLSink::processSDLEvents() {
     if (e.type == SDL_QUIT) {
       /* Click close icon then quit */
       EventLoop::instance()->exit(0);
-    }
-    else if (opts.capture_limit_reached){
+    } else if (opts.capture_limit_reached) {
       EventLoop::instance()->exit(0);
     }
   }

--- a/src/sdl_sink.cpp
+++ b/src/sdl_sink.cpp
@@ -157,6 +157,9 @@ void SDLSink::processSDLEvents() {
       /* Click close icon then quit */
       EventLoop::instance()->exit(0);
     }
+    else if (opts.capture_limit_reached){
+      EventLoop::instance()->exit(0);
+    }
   }
 }
 

--- a/src/twincam.h
+++ b/src/twincam.h
@@ -6,6 +6,7 @@
 struct options {
   unsigned long camera = 0;
   unsigned long capture_limit = 0;
+  bool capture_limit_reached = false;
   bool print_available_cameras = false;
   bool print_uptime = false;
   bool to_syslog = false;

--- a/tests/prepare_env.sh
+++ b/tests/prepare_env.sh
@@ -43,7 +43,8 @@ elif command -v dnf > /dev/null; then
   $prefix dnf install -y git gcc g++ libevent libevent-devel openssl \
     openssl-devel gnutls gnutls-devel meson boost boost-devel python3-pip \
     libdrm libdrm-devel systemd-udev doxygen cmake graphviz libatomic \
-    texlive-latex cppcheck libyaml-devel clang zip valgrind libasan findutils
+    texlive-latex cppcheck libyaml-devel clang zip valgrind libasan findutils \
+    systemd-devel
 fi
 
 $prefix pip install jinja2 ply pyyaml


### PR DESCRIPTION
Capture limit implementation for -C option

Capture limit may now be set via a -C option using`twincam -C100` as discussed. 
The application should exit after 100 frames.