### PR TITLE
Use libjpeg over SDL2_image

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,6 +60,7 @@ if libsdl2.found()
     if libjpeg.found()
         twincam_cpp_args += ['-DHAVE_LIBJPEG']
         twincam_sources += files([
+            'src/jpeg_error_manager.cpp',
             'src/sdl_texture_mjpg.cpp'
         ])
     endif

--- a/src/jpeg_error_manager.cpp
+++ b/src/jpeg_error_manager.cpp
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (C) 2022, Ideas on Board Oy
+ *
+ * jpeg_error_manager.cpp - JPEG Error Manager
+ */
+
+#include "jpeg_error_manager.h"
+
+static void errorExit(j_common_ptr cinfo) {
+  JpegErrorManager* self = reinterpret_cast<JpegErrorManager*>(cinfo->err);
+  longjmp(self->escape_, 1);
+}
+
+static void outputMessage([[maybe_unused]] j_common_ptr cinfo) {}
+
+JpegErrorManager::JpegErrorManager(struct jpeg_decompress_struct& cinfo) {
+  cinfo.err = jpeg_std_error(&errmgr_);
+  errmgr_.error_exit = errorExit;
+  errmgr_.output_message = outputMessage;
+}

--- a/src/jpeg_error_manager.h
+++ b/src/jpeg_error_manager.h
@@ -1,0 +1,21 @@
+/* SPDX-License-Identifier: GPL-2.0-or-later */
+/*
+ * Copyright (C) 2022, Ideas on Board Oy
+ *
+ * jpeg_error_manager.h - JPEG Error Manager
+ */
+
+#pragma once
+
+#include <setjmp.h>
+#include "twncm_stdio.h"
+
+#include <jpeglib.h>
+
+struct JpegErrorManager {
+  JpegErrorManager(struct jpeg_decompress_struct& cinfo);
+
+  /* Order very important for reinterpret_cast */
+  struct jpeg_error_mgr errmgr_;
+  jmp_buf escape_;
+};

--- a/src/sdl_texture_mjpg.cpp
+++ b/src/sdl_texture_mjpg.cpp
@@ -1,4 +1,5 @@
 #include "sdl_texture_mjpg.h"
+#include "jpeg_error_manager.h"
 
 #include <jpeglib.h>
 
@@ -14,15 +15,23 @@ SDLTextureMJPG::~SDLTextureMJPG() {
   free(rgbdata_);
 }
 
-void SDLTextureMJPG::decompress(const unsigned char* jpeg,
-                                unsigned long jpeg_size) {
+int SDLTextureMJPG::decompress(const Span<uint8_t>& data) {
   struct jpeg_error_mgr jerr;
   struct jpeg_decompress_struct cinfo;
   cinfo.err = jpeg_std_error(&jerr);
 
+  JpegErrorManager jpegErrorManager(cinfo);
+  if (setjmp(jpegErrorManager.escape_)) {
+    /* libjpeg found an error */
+    jpeg_destroy_decompress(&cinfo);
+
+    EPRINT("JPEG decompression error");
+    return -EINVAL;
+  }
+
   jpeg_create_decompress(&cinfo);
 
-  jpeg_mem_src(&cinfo, jpeg, jpeg_size);
+  jpeg_mem_src(&cinfo, data.data(), data.size());
 
   jpeg_read_header(&cinfo, TRUE);
 
@@ -39,9 +48,11 @@ void SDLTextureMJPG::decompress(const unsigned char* jpeg,
   jpeg_finish_decompress(&cinfo);
 
   jpeg_destroy_decompress(&cinfo);
+
+  return 0;
 }
 
 void SDLTextureMJPG::update(const Span<uint8_t>& data) {
-  decompress(data.data(), data.size());
+  decompress(data);
   SDL_UpdateTexture(ptr_, nullptr, rgbdata_, pitch_);
 }

--- a/src/sdl_texture_mjpg.h
+++ b/src/sdl_texture_mjpg.h
@@ -10,5 +10,5 @@ class SDLTextureMJPG : public SDLTexture {
 
  private:
   unsigned char* rgbdata_ = 0;
-  void decompress(const unsigned char* jpeg, unsigned long jpeg_size);
+  int decompress(const libcamera::Span<uint8_t>& data);
 };


### PR DESCRIPTION
We were using the libjpeg functionality of SDL2_image only, instead just
use libjpeg directly to reduce our dependancy count, it is a more
commonly available library.