### PR TITLE
Make sure the SELinux file type is correct for the twincam executable.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -25,3 +25,5 @@ if command -v dracut > /dev/null; then
   dracut -f
 fi
 
+# Make sure the SELinux file type is correct for the twincam executable.
+restorecon -v /usr/bin/twincam


### PR DESCRIPTION
For Fedora 36 on native x86_64, SELinux prevented the twincam systemd service
from running because the twincam executable file has type user_home_t, whereas
it needs to be bin_t.  This change is to correct the file type during the installation.
