### PR TITLE
Port libcamera changes for making line stride configurable.

### DIFF
--- a/src/sdl_sink.cpp
+++ b/src/sdl_sink.cpp
@@ -57,7 +57,7 @@ int SDLSink::configure(const libcamera::CameraConfiguration& config) {
       break;
 #endif
     case libcamera::formats::YUYV:
-      texture_ = std::make_unique<SDLTextureYUYV>(rect_);
+      texture_ = std::make_unique<SDLTextureYUYV>(rect_, cfg.stride);
       break;
     default:
       EPRINT("Unsupported pixel format %s\n",

--- a/src/sdl_texture_yuyv.cpp
+++ b/src/sdl_texture_yuyv.cpp
@@ -2,8 +2,8 @@
 
 using namespace libcamera;
 
-SDLTextureYUYV::SDLTextureYUYV(const SDL_Rect& rect)
-    : SDLTexture(rect, SDL_PIXELFORMAT_YUY2, 4 * ((rect.w + 1) / 2)) {}
+SDLTextureYUYV::SDLTextureYUYV(const SDL_Rect &rect, unsigned int stride)
+	: SDLTexture(rect, SDL_PIXELFORMAT_YUY2, stride) {}
 
 void SDLTextureYUYV::update(const Span<uint8_t>& data) {
   SDL_UpdateTexture(ptr_, &rect_, data.data(), pitch_);

--- a/src/sdl_texture_yuyv.h
+++ b/src/sdl_texture_yuyv.h
@@ -4,6 +4,6 @@
 
 class SDLTextureYUYV : public SDLTexture {
  public:
-  SDLTextureYUYV(const SDL_Rect& rect);
+  SDLTextureYUYV(const SDL_Rect& rect, unsigned int stride);
   void update(const libcamera::Span<uint8_t>& data) override;
 };


### PR DESCRIPTION
This MR is for porting a recent libcamera change to twincam:
"cam: sdl_texture_yuyv: Make line stride configurable"
