### PR TITLE
Port fix for compilation with SDL2 <2.0.16 and renaming 'pitch' to 'stride'

### DIFF
--- a/src/sdl_sink.cpp
+++ b/src/sdl_sink.cpp
@@ -57,9 +57,11 @@ int SDLSink::configure(const libcamera::CameraConfiguration& config) {
       texture_ = std::make_unique<SDLTextureMJPG>(rect_);
       break;
 #endif
+#if SDL_VERSION_ATLEAST(2, 0, 16)
     case libcamera::formats::NV12:
       texture_ = std::make_unique<SDLTextureNV12>(rect_, cfg.stride);
       break;
+#endif
     case libcamera::formats::YUYV:
       texture_ = std::make_unique<SDLTextureYUYV>(rect_, cfg.stride);
       break;

--- a/src/sdl_texture.cpp
+++ b/src/sdl_texture.cpp
@@ -4,8 +4,8 @@
 
 SDLTexture::SDLTexture(const SDL_Rect& rect,
                        SDL_PixelFormatEnum pixelFormat,
-                       const int pitch)
-    : ptr_(nullptr), rect_(rect), pixelFormat_(pixelFormat), pitch_(pitch) {}
+                       const int stride)
+    : ptr_(nullptr), rect_(rect), pixelFormat_(pixelFormat), stride_(stride) {}
 
 SDLTexture::~SDLTexture() {
   if (ptr_)

--- a/src/sdl_texture.h
+++ b/src/sdl_texture.h
@@ -10,7 +10,7 @@ class SDLTexture {
  public:
   SDLTexture(const SDL_Rect& rect,
              SDL_PixelFormatEnum pixelFormat,
-             const int pitch);
+             const int stride);
   virtual ~SDLTexture();
   int create(SDL_Renderer* renderer);
   virtual void update(
@@ -21,5 +21,5 @@ class SDLTexture {
   SDL_Texture* ptr_;
   const SDL_Rect rect_;
   const SDL_PixelFormatEnum pixelFormat_;
-  int pitch_;
+  const int stride_;
 };

--- a/src/sdl_texture_mjpg.cpp
+++ b/src/sdl_texture_mjpg.cpp
@@ -8,7 +8,7 @@ using namespace libcamera;
 
 SDLTextureMJPG::SDLTextureMJPG(const SDL_Rect& rect)
     : SDLTexture(rect, SDL_PIXELFORMAT_RGB24, rect.w * 3),
-      rgb_(std::make_unique<unsigned char[]>(pitch_ * rect.h)) {}
+      rgb_(std::make_unique<unsigned char[]>(stride_ * rect.h)) {}
 
 int SDLTextureMJPG::decompress(const Span<const uint8_t>& data) {
   struct jpeg_decompress_struct cinfo;
@@ -29,7 +29,7 @@ int SDLTextureMJPG::decompress(const Span<const uint8_t>& data) {
   jpeg_start_decompress(&cinfo);
 
   for (int i = 0; cinfo.output_scanline < cinfo.output_height; ++i) {
-    JSAMPROW rowptr = rgb_.get() + i * pitch_;
+    JSAMPROW rowptr = rgb_.get() + i * stride_;
     jpeg_read_scanlines(&cinfo, &rowptr, 1);
   }
 
@@ -43,5 +43,5 @@ int SDLTextureMJPG::decompress(const Span<const uint8_t>& data) {
 void SDLTextureMJPG::update(
     const std::vector<libcamera::Span<const uint8_t>>& data) {
   decompress(data[0]);
-  SDL_UpdateTexture(ptr_, nullptr, rgb_.get(), pitch_);
+  SDL_UpdateTexture(ptr_, nullptr, rgb_.get(), stride_);
 }

--- a/src/sdl_texture_nv12.cpp
+++ b/src/sdl_texture_nv12.cpp
@@ -2,11 +2,13 @@
 
 using namespace libcamera;
 
+#if SDL_VERSION_ATLEAST(2, 0, 16)
 SDLTextureNV12::SDLTextureNV12(const SDL_Rect& rect, unsigned int stride)
     : SDLTexture(rect, SDL_PIXELFORMAT_NV12, stride) {}
 
 void SDLTextureNV12::update(
     const std::vector<libcamera::Span<const uint8_t>>& data) {
-  SDL_UpdateNVTexture(ptr_, &rect_, data[0].data(), pitch_, data[1].data(),
-                      pitch_);
+  SDL_UpdateNVTexture(ptr_, &rect_, data[0].data(), stride_, data[1].data(),
+                      stride_);
 }
+#endif

--- a/src/sdl_texture_nv12.h
+++ b/src/sdl_texture_nv12.h
@@ -2,8 +2,10 @@
 
 #include "sdl_texture.h"
 
+#if SDL_VERSION_ATLEAST(2, 0, 16)
 class SDLTextureNV12 : public SDLTexture {
  public:
   SDLTextureNV12(const SDL_Rect& rect, unsigned int stride);
   void update(const std::vector<libcamera::Span<const uint8_t>>& data) override;
 };
+#endif

--- a/src/sdl_texture_yuyv.cpp
+++ b/src/sdl_texture_yuyv.cpp
@@ -7,5 +7,5 @@ SDLTextureYUYV::SDLTextureYUYV(const SDL_Rect& rect, unsigned int stride)
 
 void SDLTextureYUYV::update(
     const std::vector<libcamera::Span<const uint8_t>>& data) {
-  SDL_UpdateTexture(ptr_, &rect_, data[0].data(), pitch_);
+  SDL_UpdateTexture(ptr_, &rect_, data[0].data(), stride_);
 }


### PR DESCRIPTION
This PR is for merging the following commits from libcamera:
"cam: sdl_sink: Fix compilation with SDL2 <2.0.16"
"cam: sdl_texture: Rename 'pitch' to 'stride'"

https://github.com/kbingham/libcamera/commit/fe8941d7d61bd22ed66e5b5615e931c68fdf9bfa
https://github.com/kbingham/libcamera/commit/1590e9b2b8c1b8b120a9b0dd6a53f4ef1298b2a0

I tested twincam for NV12 format on x86_64 with Logitech BRIO webcam.