### PR TITLE
Add capture limit option

### DIFF
--- a/src/camera_session.cpp
+++ b/src/camera_session.cpp
@@ -128,6 +128,7 @@ int CameraSession::start() {
 
   queueCount_ = 0;
   captureCount_ = 0;
+  captureLimit_ = opts.cl;
 
   ret = camera_->configure(config_.get());
   if (ret < 0) {
@@ -291,6 +292,12 @@ int CameraSession::queueRequest(Request* request) {
 }
 
 void CameraSession::requestComplete(Request* request) {
+  if (opts.cl > 0) {
+    if (captureCount_ >= captureLimit_) {
+      EventLoop::instance()->exit(0);
+      return;
+    }
+  }
   if (request->status() == Request::RequestCancelled)
     return;
 

--- a/src/camera_session.h
+++ b/src/camera_session.h
@@ -67,6 +67,7 @@ class CameraSession {
 
   unsigned int queueCount_ = 0;
   unsigned int captureCount_ = 0;
+  unsigned int captureLimit_ = 0;
   const libcamera::CameraManager* const cm_ = nullptr;
 
 #if 0  // not priority right now, for MJPG mainly

--- a/src/twincam.cpp
+++ b/src/twincam.cpp
@@ -467,6 +467,7 @@ static int processArgs(int argc, char** argv) {
                                    {"kill", no_argument, 0, 'k'},
                                    {"list-cameras", no_argument, 0, 'l'},
                                    {"new-root-dir", no_argument, 0, 'n'},
+                                   {"capture-limit", required_argument, 0, 'C'},
                                    {"pixel-format", required_argument, 0, 'p'},
 #ifdef HAVE_SDL
                                    {"sdl", no_argument, 0, 'S'},
@@ -476,7 +477,7 @@ static int processArgs(int argc, char** argv) {
                                    {"verbose", no_argument, 0, 'v'},
                                    {NULL, 0, 0, '\0'}};
 
-  for (int opt; (opt = getopt_long(argc, argv, "c:dDF:fhklnp:Ssuv", options,
+  for (int opt; (opt = getopt_long(argc, argv, "c:dDF:fhklnC:p:Ssuv", options,
                                    NULL)) != -1;) {
     int fd;
     char buf[16];
@@ -519,6 +520,9 @@ static int processArgs(int argc, char** argv) {
         kill(twncm_atoi(buf), SIGUSR1);
 
         return 1;
+      case 'C':
+        opts.cl = twncm_atoi(optarg);
+        break;
       case 'p':
         opts.pf = optarg;
         break;
@@ -557,6 +561,7 @@ static int processArgs(int argc, char** argv) {
             "  -l, --list-cameras  List cameras\n"
             "  -n, --new-root-dir  chroot to /sysroot (sends SIGUSR1 to "
             "pidfile pid)\n"
+            "  -C, --capture-limit Define a limited number of frames captured\n"
             "  -p, --pixel-format  Select pixel format\n"
 #ifdef HAVE_SDL
             "  -S, --sdl           Display viewfinder through SDL\n"

--- a/src/twincam.h
+++ b/src/twincam.h
@@ -13,6 +13,7 @@ struct options {
   bool to_syslog = false;
   bool uptime = false;
   bool verbose = false;
+  long cl = -1;
 #ifdef HAVE_SDL
   bool sdl = false;
 #endif


### PR DESCRIPTION
Currently the camera will continue to capture frames until the user interrupts by SIGINT. The capture limit option allows the user to determine the number of frames for capture required before exiting.

Ref issue: https://github.com/ericcurtin/twincam/issues/26