### PR TITLE
Fedora 36 to Fedora 39

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # twincam
 
 [![GitHub Build Status](https://github.com/inotify-tools/inotify-tools/workflows/build/badge.svg)](https://github.com/ericcurtin/twincam/actions)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ericcurtin_twincam&metric=bugs)](https://sonarcloud.io/summary/new_code?id=ericcurtin_twincam)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ericcurtin_twincam&metric=code_smells)](https://sonarcloud.io/summary/new_code?id=ericcurtin_twincam)
 
 A lightweight camera application, designed to start quickly in a bare
 environment. It is named twincam as it is built with automotive in mind

--- a/lib/dracut/modules.d/81twincam/module-setup.sh
+++ b/lib/dracut/modules.d/81twincam/module-setup.sh
@@ -23,22 +23,5 @@ install() {
     inst_libdir_file "libcamera/ipa_*.so*"
     inst_libdir_file "libevent-*.so*"
     inst_libdir_file "libstdc++.so*"
-
-    # Required if using Fedora SDL2
-    inst_libdir_file "libSDL2*.so*"
-    inst_libdir_file "libgbm*.so*"
-    # inst_libdir_file "dri/*.so*" pulls in massive libLLVM which we don't need
-    inst_libdir_file "libOpenGL*.so*"
-    inst_libdir_file "libEGL*.so*"
-
-    # Required for MJPEG
-    inst_libdir_file "libjpeg.so*"
-#    inst_libdir_file "egl_vendor.d/*.json"
-
-#    inst_dir "/usr/share/glvnd/egl_vendor.d"
-#    inst_multiple "/usr/share/glvnd/egl_vendor.d/*.json"
-
-#    inst_dir "/usr/share/plymouth/themes/external-command/"
-#    inst_multiple "/usr/share/plymouth/themes/external-command/*.plymouth"
 }
 

--- a/tests/run-all.sh
+++ b/tests/run-all.sh
@@ -9,7 +9,7 @@ elif command -v docker > /dev/null; then
 fi
 
 container_run() {
-  cmd="tests/prepare_env.sh && tests/build_twincam.sh && tests/sonar.sh && tests/cpp_check.sh"
+  cmd="tests/prepare_env.sh && tests/build_twincam.sh"
   id=$(sudo $container run --cap-add=SYS_PTRACE -d -it $1 /bin/bash)
   sudo $container exec -it $id /bin/bash -c "mkdir -p $PWD"
   sudo $container cp $PWD $id:$PWD/..
@@ -19,7 +19,7 @@ container_run() {
 
 if [ -n "$container" ]; then
   container_run "centos:stream9"
-  container_run "fedora:36"
+  container_run "fedora:39"
   container_run "ubuntu:22.04"
   exit 0
 fi


### PR DESCRIPTION
Lets get to a somewhat recent version of Fedora. Drop SonarCloud also.
Also remove cppcheck in the build, also too much maintenance, if someone
wants to run locally as a helper tool could be useful.
